### PR TITLE
Allow both relative and absolute module paths.

### DIFF
--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Common.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Common.hs
@@ -38,12 +38,12 @@ fileInDirWithExtensionAndComponents ::
        MonadIO m
     => m (Path Abs Dir)
     -> String
-    -> Path Rel File
+    -> Path Abs File
     -> [String]
     -> m (Path Abs File)
 fileInDirWithExtensionAndComponents genDir ext f comps = do
     dd <- genDir
-    let fileStr = intercalate "-" $ dropExtensions (toFilePath f) : comps
+    let fileStr = intercalate "-" $ dropExtensions (toFilePath $ filename f) : comps
     liftIO $ (dd </>) <$> parseRelFile (concat [fileStr, ".", ext])
 
 signatureInferenceStrategies :: [ES.SignatureInferenceStrategy]

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Averages.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Averages.hs
@@ -216,7 +216,7 @@ instance FromJSON AverageEvaluatorOutput where
 
 data AverageCsvLine = AverageCsvLine
     { averageCsvLineBaseDir :: Path Abs Dir
-    , averageCsvLineSourceFile :: Path Rel File
+    , averageCsvLineSourceFile :: Path Abs File
     , averageCsvLineEvaluatorName :: String
     , averageCsvLineStrategyName :: String
     , averageCsvLineAverage :: AverageOutput
@@ -273,15 +273,15 @@ makeAverageCsvLinesFromAverageEvaluatorOutput is stratName AverageEvaluatorOutpu
     }
 
 jsonAverageFileWithComponents ::
-       MonadIO m => Path Rel File -> [String] -> m (Path Abs File)
+       MonadIO m => Path Abs File -> [String] -> m (Path Abs File)
 jsonAverageFileWithComponents = averagesFile "json"
 
 csvAverageFileWithComponents ::
-       MonadIO m => Path Rel File -> [String] -> m (Path Abs File)
+       MonadIO m => Path Abs File -> [String] -> m (Path Abs File)
 csvAverageFileWithComponents = averagesFile "csv"
 
 averagesFile ::
-       MonadIO m => String -> Path Rel File -> [String] -> m (Path Abs File)
+       MonadIO m => String -> Path Abs File -> [String] -> m (Path Abs File)
 averagesFile = fileInDirWithExtensionAndComponents averagesDir
 
 averagesDir :: MonadIO m => m (Path Abs Dir)

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Common/TH.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Common/TH.hs
@@ -55,8 +55,7 @@ makeExampleCache = do
                 putStrLn $
                     unlines $
                     [ "Gathering a cache of the functions defined in the following file:"
-                    , toFilePath $
-                      ES.inputSpecBaseDir ex </> ES.inputSpecFile ex
+                    , toFilePath $ ES.inputSpecFile ex
                     , unwords
                           [ "Found these"
                           , show (length ns)

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Files.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Files.hs
@@ -84,7 +84,7 @@ dataFileForStrategy ::
 dataFileForStrategy = evaluatedFileForStrategy
 
 csvDataFileWithComponents ::
-       MonadIO m => Path Rel File -> [String] -> m (Path Abs File)
+       MonadIO m => Path Abs File -> [String] -> m (Path Abs File)
 csvDataFileWithComponents = dataFileWithComponents "csv"
 
 dataFilesForGroupAndExample ::
@@ -118,7 +118,7 @@ allDataFile :: MonadIO m => m (Path Abs File)
 allDataFile = evaluatedFileForAllData
 
 dataFileWithComponents ::
-       MonadIO m => String -> Path Rel File -> [String] -> m (Path Abs File)
+       MonadIO m => String -> Path Abs File -> [String] -> m (Path Abs File)
 dataFileWithComponents = fileInDirWithExtensionAndComponents dataDir
 
 --

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Raw.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Data/Raw.hs
@@ -43,7 +43,7 @@ rawDataRulesForGroupFileNameAndStrat ::
 rawDataRulesForGroupFileNameAndStrat ghciResource groupName is name infStrat = do
     jsonF <- rawDataFileFor groupName is name infStrat
     jsonF $%> do
-        let absFile = ES.inputSpecAbsFile is
+        let absFile = ES.inputSpecFile is
         needP [absFile]
         ip <-
             withResource ghciResource 1 $ do

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Hackage.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Hackage.hs
@@ -64,8 +64,8 @@ packageExamples (package, sourceDirs, modulePaths) = do
             fmap catMaybes $
             forM modulePaths $ \modulePath -> do
                 bd <- liftIO $ resolveDir pd sourceDir
-                fp <- liftIO $ parseRelFile $ modulePath ++ ".hs"
-                exists <- liftIO $ Path.IO.doesFileExist $ bd </> fp
+                fp <- liftIO . resolveFile bd $ modulePath ++ ".hs"
+                exists <- liftIO $ Path.IO.doesFileExist fp
                 pure $
                     if exists
                         then Just

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Plots/Files.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Analyse/Plots/Files.hs
@@ -24,12 +24,14 @@ scriptFile :: MonadIO m => String -> m (Path Abs File)
 scriptFile fname = liftIO $ resolveFile' $ "rscripts/" ++ fname
 
 pdfPlotFileWithComponents ::
-       MonadIO m => Path Rel File -> [String] -> m (Path Abs File)
+       MonadIO m => Path Abs File -> [String] -> m (Path Abs File)
 pdfPlotFileWithComponents = fileInDirWithExtensionAndComponents plotsDir "pdf"
 
 exampleModule :: Example -> String
 exampleModule = map go . dropExtensions . toFilePath . ES.inputSpecFile
   where
+    -- TODO: This method of converting paths to module names is just
+    -- incorrect.
     go :: Char -> Char
     go '/' = '.'
     go c = c

--- a/easyspec-evaluate/src/EasySpec/Evaluate/OptParse.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/OptParse.hs
@@ -32,14 +32,9 @@ combineToInstructions cmd Flags Configuration = (,) <$> disp <*> pure Settings
                 bd <- resolveDir' dirpath
                 fs <-
                     case mfilepath of
-                        Just f -> do
-                            af <- resolveFile' f
-                            rf <- makeRelative bd af
-                            pure [rf]
+                        Just f -> pure <$> resolveFile' f
                         Nothing ->
-                            (mapMaybe (makeRelative bd) .
-                             filter ES.isSourceFile . snd) <$>
-                            listDirRecur bd
+                          filter ES.isSourceFile . snd <$> listDirRecur bd
                 pure $ DispatchEvaluate $ map (ES.InputSpec bd) fs
             CommandBuild target -> pure $ DispatchBuild target
             CommandBuildEverything -> pure DispatchBuildEverything

--- a/easyspec-evaluate/src/EasySpec/Evaluate/Types.hs
+++ b/easyspec-evaluate/src/EasySpec/Evaluate/Types.hs
@@ -94,7 +94,7 @@ instance FromJSON EvaluationInputPoint where
 
 data EvaluatorCsvLine = EvaluatorCsvLine
     { eclBaseDir :: Path Abs Dir
-    , eclFile :: Path Rel File
+    , eclFile :: !(Path Abs File)
     , eclStratName :: String
     , eclFocusFuncName :: String
     , eclEvaluatorName :: ES.EvaluatorName
@@ -106,7 +106,7 @@ data EvaluatorCsvLine = EvaluatorCsvLine
 
 instance FromNamedRecord EvaluatorCsvLine where
     parseNamedRecord r =
-        EvaluatorCsvLine <$> p parseAbsDir "base-dir" <*> p parseRelFile "file" <*>
+        EvaluatorCsvLine <$> p parseAbsDir "base-dir" <*> p parseAbsFile "file" <*>
         r .: "strategy" <*>
         r .: "focus" <*>
         r .: "evaluator" <*>

--- a/easyspec/easyspec.cabal
+++ b/easyspec/easyspec.cabal
@@ -71,6 +71,12 @@ library
         unordered-containers >=0.2 && <0.3,
         vector >=0.11 && <0.12,
         exceptions >=0.8 && <0.9
+      , binary
+      , bytestring >= 0.10
+      , deepseq
+      , fingertree >= 0.1.1
+      , text >= 1.2
+      , quickspec
     default-language: Haskell2010
     default-extensions: NoImplicitPrelude
     hs-source-dirs: src/

--- a/easyspec/src/EasySpec/Discover/SourceGathering.hs
+++ b/easyspec/src/EasySpec/Discover/SourceGathering.hs
@@ -28,7 +28,7 @@ gatherSourceOf is d@IdData {..} = do
             (_:_) -> pure Nothing
         -- It was defined locally, so we may be able to get the implementation out of the current file.
             [] -> do
-                let sourceFile = inputSpecAbsFile is
+                let sourceFile = inputSpecFile is
                 mainContents <- liftIO $ readFile $ toFilePath sourceFile
                 case parseModule mainContents of
                     ParseFailed loc err -> do

--- a/easyspec/src/EasySpec/Discover/Types.hs
+++ b/easyspec/src/EasySpec/Discover/Types.hs
@@ -57,11 +57,8 @@ deriving instance TH.Lift l => TH.Lift (SpecialCon l)
 
 data InputSpec = InputSpec
     { inputSpecBaseDir :: Path Abs Dir
-    , inputSpecFile :: Path Rel File
+    , inputSpecFile :: !(Path Abs File)
     } deriving (Show, Eq, Data, Typeable, TH.Lift)
-
-inputSpecAbsFile :: InputSpec -> Path Abs File
-inputSpecAbsFile InputSpec {..} = inputSpecBaseDir </> inputSpecFile
 
 data SignatureInferenceStrategy = SignatureInferenceStrategy
     { sigInfStratName :: String
@@ -119,7 +116,7 @@ data Id m = Id
     { idName :: QName m
     , idType :: Type m
     , idImpl :: Maybe (Impl m)
-    , idRootloc :: Maybe (Path Rel File) -- The module name where it was defined
+    , idRootloc :: !(Maybe (Path Abs File)) -- The module name where it was defined
     } deriving (Show, Eq, Ord, Generic)
 
 type EasyId = Id ()

--- a/easyspec/src/EasySpec/OptParse.hs
+++ b/easyspec/src/EasySpec/OptParse.hs
@@ -33,11 +33,11 @@ combineToInstructions cmd Flags {..} Configuration = (,) <$> disp <*> sets
         case cmd of
             CommandDiscover DiscoverArgs {..} ->
                 DispatchDiscover <$> do
-                    file <- parseRelFile argDiscFile
                     dir <-
                         case argDiscBaseDir of
                             Nothing -> getCurrentDir
                             Just bd -> resolveDir' bd
+                    file <- resolveFile dir argDiscFile
                     infStrat <-
                         case argDiscInfStratName of
                             Nothing -> pure defaultInferenceStrategy
@@ -81,6 +81,7 @@ combineToInstructions cmd Flags {..} Configuration = (,) <$> disp <*> sets
                                             , show e
                                             ]
                     let is = InputSpec dir file
+                    mname <- filePathToModuleName $ inputSpecFile is
                     let unqualification =
                             case argDiscUnqualified of
                                 UnqAll -> UnqualifyAll
@@ -89,10 +90,7 @@ combineToInstructions cmd Flags {..} Configuration = (,) <$> disp <*> sets
                                     UnqualifyLocal $
                                     case f of
                                         Just (Qual _ mn _) -> mn
-                                        _ ->
-                                            ModuleName () $
-                                            filePathToModuleName $
-                                            inputSpecFile is
+                                        _ -> ModuleName () mname
                     pure
                         DiscoverSettings
                         { setDiscInputSpec = is

--- a/easyspec/src/EasySpec/Utils.hs
+++ b/easyspec/src/EasySpec/Utils.hs
@@ -27,7 +27,5 @@ isSourceFile p =
     let e = fileExtension p
     in e == ".hs" || e == ".lhs"
 
-sourcesIn :: MonadIO m => Path Abs Dir -> m [Path Rel File]
-sourcesIn dir = do
-    fs <- liftIO $ (filter isSourceFile . snd) <$> listDirRecur dir
-    pure $ mapMaybe (stripDir dir) fs
+sourcesIn :: MonadIO m => Path Abs Dir -> m [Path Abs File]
+sourcesIn dir = liftIO $ filter isSourceFile . snd <$> listDirRecur dir

--- a/easyspec/test/EasySpec/Discover/SourceGatheringSpec.hs
+++ b/easyspec/test/EasySpec/Discover/SourceGatheringSpec.hs
@@ -22,7 +22,7 @@ spec =
                  ]) $ \ex -> do
         ghcEasyIds <- runReaderT (getEasyIds ex) defaultSettings
         -- the hse ids
-        pr <- parseFile $ toFilePath $ inputSpecAbsFile ex
+        pr <- parseFile $ toFilePath $ inputSpecFile ex
         md <-
             case pr of
                 ParseFailed srcloc err ->

--- a/easyspec/test/TestUtils.hs
+++ b/easyspec/test/TestUtils.hs
@@ -64,7 +64,7 @@ allExamples =
 
 getHSEEasyIds :: InputSpec -> IO [EasyId]
 getHSEEasyIds is = do
-    pr <- parseFile $ toFilePath $ inputSpecAbsFile is
+    pr <- parseFile $ toFilePath $ inputSpecFile is
     case pr of
         ParseFailed srcloc err ->
             fail $


### PR DESCRIPTION
This allows for the following to work:

```
[nix-shell:~/programming/easyspec]$ stack build --nix easyspec && stack exec --nix -- easyspec discover ../../../../tmp/MySort.hs MySort.mySort
mySort xs <= xs = y <= y
mySort (mySort xs) = mySort xs

[nix-shell:~/programming/easyspec]$ stack build --nix easyspec && stack exec --nix -- easyspec discover /tmp/MySort.hs MySort.mySort
mySort xs <= xs = y <= y
mySort (mySort xs) = mySort xs
```

I may or may not have broken stuff in `easyspec-evaluate`: I mostly
just changed the types to line up there. If there's a good way to test
that, I can do it.

Not only can we use absolute paths now, relative paths of the
`src/Foo/Bar.hs` sort are fixed: we ask GHC to give us the module name
instead of trying to guess it. In general it's not possible to guess a
module name from the file path with any accuracy.